### PR TITLE
remove wis2 subcommand in CLI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ python3 setup.py install
 
 ## Running
 
-The canonical URL for the GDC is https://api.weather.gc.ca/collections/wis2-discovery-metadata.
+The canonical URL for the GDC is https://api.weather.gc.ca.
 
 To use a different catalogue, set the `PYWISCAT_GDC_URL` environmnent variable before running pywiscat.
 
@@ -47,16 +47,19 @@ pywiscat --version
 ## WIS2 workflows
 
 # search the WIS2 Global Discovery Catalogue (GDC)
-pywiscat wis2 search
+pywiscat search
 
 # search the WIS2 Global Discovery Catalogue (GDC) with a full text query
-pywiscat wis2 search -q radar
+pywiscat search --query radar
+
+# search the WIS2 Global Discovery Catalogue (GDC) for only recommended data
+pywiscat search --data-policy recommended
 
 # search the WIS2 Global Discovery Catalogue (GDC) with a bounding box query
-pywiscat wis2 search --bbox -142,42.-52,84
+pywiscat search --bbox -142,42,-52,84
 
 # get more information about a WIS2 GDC record
-pywiscat wis2 get urn:x-wmo:md:can:eccc-msc:c7c9d726-c48a-49e3-98ab-78a1ab87cda8
+pywiscat get urn:x-wmo:md:can:eccc-msc:c7c9d726-c48a-49e3-98ab-78a1ab87cda8
 ```
 
 ## Using the API

--- a/pywiscat.env
+++ b/pywiscat.env
@@ -1,1 +1,1 @@
-PYWISCAT_GDC_URL=https://api.weather.gc.ca/collections/wis2-discovery-metadata
+PYWISCAT_GDC_URL=https://api.weather.gc.ca

--- a/pywiscat/__init__.py
+++ b/pywiscat/__init__.py
@@ -2,7 +2,7 @@
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #
-# Copyright (c) 2023 Tom Kralidis
+# Copyright (c) 2024 Tom Kralidis
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -29,7 +29,7 @@
 
 import click
 
-from pywiscat.wis2 import wis2
+from pywiscat.wis2.catalogue import get_gdc_record, search_gdc
 
 __version__ = '0.1.dev0'
 
@@ -40,4 +40,5 @@ def cli():
     pass
 
 
-cli.add_command(wis2)
+cli.add_command(search_gdc)
+cli.add_command(get_gdc_record)


### PR DESCRIPTION
- remove `wis2` subcomment on CLI (e.g. `pywiscat wis2 search` -> `pywiscat search`
- set GDC URL as base URL, let code determine `/collections/wis2-discovery-metadata`
- add Python versions to CI
- add data policy parameter to search CLI